### PR TITLE
fix: use pyproject version for autorelease

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -40,6 +40,8 @@ jobs:
           github-token: ${{ env.RELEASE_TOKEN }}
           output-file: 'CHANGELOG.md'
           git-branch: ${{ env.CHANGELOG_BRANCH }}
+          version-file: 'pyproject.toml'
+          version-path: 'project.version'
 
       - name: Check if release already exists
         id: release_check

--- a/tests/pulumi/test_delivery_contracts.py
+++ b/tests/pulumi/test_delivery_contracts.py
@@ -132,6 +132,8 @@ def test_release_workflows_use_repo_token_with_github_token_fallback() -> None:
         assert checkout_step["with"]["fetch-depth"] == 0
         assert checkout_step["with"]["persist-credentials"] is False
         assert changelog_step["with"]["git-branch"] == "${{ env.CHANGELOG_BRANCH }}"
+        assert changelog_step["with"]["version-file"] == "pyproject.toml"
+        assert changelog_step["with"]["version-path"] == "project.version"
         assert workflow["concurrency"]["cancel-in-progress"] is False
 
 


### PR DESCRIPTION
# Pull Request

## Description

Switch the autorelease workflow to the repositorys actual version source by configuring `TriPSs/conventional-changelog-action` to bump `project.version` in `pyproject.toml` instead of its default `package.json` fallback. Add a delivery-contract assertion so the release workflow cannot drift back to a missing version file.

## Related Issue

- Closes #32

## Motivation and Context

The main-branch autorelease job failed in `Conventional Changelog Action` because this repo no longer has a `package.json`. The action created a synthetic file, fell back to `0.1.0`, and then failed when it tried to create the already-existing `v0.1.0` tag.

## How Has This Been Tested?

- `docker compose --env-file .env run --rm pulumi uv run pytest -q tests/pulumi/test_delivery_contracts.py -k release_workflows_use_repo_token_with_github_token_fallback`
- `make test-actionlint`

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/infrastructure-template/blob/main/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] You have only one commit (if not, squash them into one commit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation with improved version management configuration to ensure consistent versioning across releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->